### PR TITLE
adjust generate-index.sh to work without installing uconv on Mac

### DIFF
--- a/scripts/generate-index.sh
+++ b/scripts/generate-index.sh
@@ -20,4 +20,4 @@ format_as_markdown_row() {
     awk '{printf "| %s | ![%s](all-the-bufo/%s) |\n", $0, $0, $0}'
 }
 
-find_image_files | extract_filename | uconv -x any-nfc | LC_ALL=C sort | uniq | format_as_markdown_row >> "$index_file"
+find_image_files | extract_filename | python3 -c "import sys, unicodedata; [sys.stdout.write(unicodedata.normalize('NFC', line)) for line in sys.stdin]" | LC_ALL=C sort | uniq | format_as_markdown_row >> "$index_file"


### PR DESCRIPTION
Hi guys. :wave: 

I didn't test the generate script change on Mac and just realized `uconv` isn't installed by default on Macs. I switched that part to Python and tested on Mac and Linux and it works fine and generates an identical index to what is committed.

And the time is still blazing fast:
```
time scripts/generate-index.sh

real	0m0.015s
user	0m0.016s
sys	    0m0.005s
```

Sorry! :sweat_smile: 